### PR TITLE
testcase for not available yast modules

### DIFF
--- a/spec/tftp.rb
+++ b/spec/tftp.rb
@@ -16,6 +16,11 @@ describe "SLES 12 TFTP server " do
     run_test_script("host.sh")
   end
 
+  # bug 925381
+  it "checks, for unsupported YAST modules" do
+    run_test_script("unsupported_modules.sh")
+  end
+
   after(:all) do
     # Shutdown the vagrant box.
     $vm.stop

--- a/spec/tftp.rb
+++ b/spec/tftp.rb
@@ -17,7 +17,7 @@ describe "SLES 12 TFTP server " do
   end
 
   # bug 925381
-  it "checks, for unsupported YAST modules" do
+  it "checks, whether unsupported YaST modules are reported" do
     run_test_script("unsupported_modules.sh")
   end
 

--- a/spec/tftp.xml
+++ b/spec/tftp.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <!-- These are not supported anymore -->
+  <sshd>
+    <x config:type="boolean">false</x>
+  </sshd>
+  <autofs>
+    <x config:type="boolean">false</x>
+  </autofs>
+  <restore>
+    <x config:type="boolean">false</x>
+  </restore>
 
   <general>
     <mode>
@@ -77,7 +87,7 @@ chmod 755 /srv/tftpboot
     <errors>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
+      <timeout config:type="integer">10</timeout>
     </errors>
     <messages>
       <log config:type="boolean">true</log>

--- a/spec/tftp.xml
+++ b/spec/tftp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-  <!-- These are not supported anymore -->
+  <!-- These are not supported anymore; bug 925381 -->
   <sshd>
     <x config:type="boolean">false</x>
   </sshd>
@@ -87,6 +87,8 @@ chmod 755 /srv/tftpboot
     <errors>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
+      <!-- Error popup of not supported YaST modules must disapper
+        after 10 seconds in order not stopping the installation. Bug 925381 -->
       <timeout config:type="integer">10</timeout>
     </errors>
     <messages>

--- a/spec/unsupported_modules.sh
+++ b/spec/unsupported_modules.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+set -e -x
+grep "Could not process these unsupported profile sections: \[\"autofs\", \"restore\", \"sshd\"\]" /var/log/YaST2/y2log && echo "AUTOYAST OK"

--- a/spec/unsupported_modules.sh
+++ b/spec/unsupported_modules.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 set -e -x
-grep "Could not process these unsupported profile sections: \[\"autofs\", \"restore\", \"sshd\"\]" /var/log/YaST2/y2log && echo "AUTOYAST OK"
+grep "Could not process these unsupported profile sections: \[\"autofs\", \"restore\", \"sshd\"\]"\
+ /var/log/YaST2/y2log && echo "AUTOYAST OK"


### PR DESCRIPTION
I have added it to this testcase because it is not worth to generate a single one for it.
Running one testcase takes about 45 min on a slow machine.