### PR TITLE
Save YaST2 logs when some test fails

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -73,4 +73,4 @@ end
 # Temporary files
 CLEAN.include("build_iso/cache", "kiwi/import_state.yaml")
 # Final products
-CLOBBER.include("iso", "kiwi/autoyast.box", "kiwi/iso/testing.iso")
+CLOBBER.include("iso", "kiwi/autoyast.box", "kiwi/iso/testing.iso", "log")

--- a/helper/spec_helper.rb
+++ b/helper/spec_helper.rb
@@ -31,6 +31,35 @@ def run_test_script(script, expected = "AUTOYAST OK")
   end
 end
 
+# Copy YaST2 logs from virtual machine to a given directory
+#
+# The logs will be stored in a tar.gz file. To avoid collisions,
+# the compressed file's name will contain a timestamp.
+#
+# @param [Pennyworth::VM] vm   Virtual machine
+# @param [String]         dest Directory where the logs will be stored.
+def copy_logs(vm, dest = "log")
+  tar_path = "/var/log/YaST2-#{Time.now.strftime('%Y%m%d%H%M%S')}.tar.gz"
+  FileUtils.mkdir(dest) unless Dir.exists?(dest)
+  vm.run_command("/bin/tar cfz #{tar_path} /var/log/YaST2", as: "root")
+  vm.extract_file(tar_path, dest)
+end
+
 RSpec.configure do |config|
   config.vagrant_dir = File.join( Dir.getwd, "vagrant" )
+
+  config.before(:all) do
+    # Start the previously create vagrant VM - opensuse_vm.
+    $vm = start_system(box: "autoyast_vm")
+
+    # This is the only way of execute this after(:all) block
+    # before the system is stopped.
+    self.class.after(:all) do
+      examples = RSpec.world.filtered_examples.values.flatten
+      # Copy the logs if some test fails.
+      if examples.any?(&:exception)
+        copy_logs($vm)
+      end
+    end
+  end
 end

--- a/spec/http.rb
+++ b/spec/http.rb
@@ -1,18 +1,7 @@
 require_relative "../helper/spec_helper.rb"
 
 describe "SLES 12 HTTP server " do
-
-  before(:all) do
-    # Start the previously create vagrant VM - opensuse_vm. 
-    $vm = start_system(box: "autoyast_vm")
-  end
-
   it "checks, apache2 and firewall is running correctly" do
     run_test_script("http.sh")
-  end
-
-  after(:all) do
-    # Shutdown the vagrant box.
-    $vm.stop
   end
 end

--- a/spec/lvm.rb
+++ b/spec/lvm.rb
@@ -1,12 +1,6 @@
 require_relative "../helper/spec_helper.rb"
 
 describe "LVM partition;" do
-
-  before(:all) do
-    # Start the previously create vagrant VM - opensuse_vm. 
-    $vm = start_system(box: "autoyast_vm")
-  end
-
   it "creates lvm partitions" do
     run_test_script("lvm.sh")
   end
@@ -19,10 +13,5 @@ describe "LVM partition;" do
   # bnc #928987
   it "sets peer/restrict in autoinst.xml by using default ntp.conf" do
     run_test_script("ntp.sh")
-  end
-
-  after(:all) do
-    # Shutdown the vagrant box.
-    $vm.stop
   end
 end

--- a/spec/sles12.rb
+++ b/spec/sles12.rb
@@ -1,12 +1,6 @@
 require_relative "../helper/spec_helper.rb"
 
 describe "SLES 12 checks," do
-
-  before(:all) do
-    # Start the previously create vagrant VM - opensuse_vm. 
-    $vm = start_system(box: "autoyast_vm")
-  end
-
   it "if user -vagrant- has been created" do
     run_test_script("user.sh")
   end
@@ -51,10 +45,5 @@ describe "SLES 12 checks," do
 
   it "after installation snapshot has been created" do
     run_test_script("installation_snapshot.sh")
-  end
-
-  after(:all) do
-    # Shutdown the vagrant box.
-    $vm.stop
   end
 end

--- a/spec/tftp.rb
+++ b/spec/tftp.rb
@@ -1,12 +1,6 @@
 require_relative "../helper/spec_helper.rb"
 
 describe "SLES 12 TFTP server " do
-
-  before(:all) do
-    # Start the previously create vagrant VM - opensuse_vm. 
-    $vm = start_system(box: "autoyast_vm")
-  end
-
   it "checks, tftp is running correctly" do
     run_test_script("tftp.sh")
   end
@@ -19,10 +13,5 @@ describe "SLES 12 TFTP server " do
   # bug 925381
   it "checks, whether unsupported YaST modules are reported" do
     run_test_script("unsupported_modules.sh")
-  end
-
-  after(:all) do
-    # Shutdown the vagrant box.
-    $vm.stop
   end
 end


### PR DESCRIPTION
* Logs are saved to logs/ folder.
* They'll be deleted by the 'clobber' task.
* BTW, move before/after hooks to helper/spec_helper.rb file.
* If Pennyworth PR#88 is accepted, the after(:all) definition could
  be improved.