### PR TITLE
Disable /vagrant mount point

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -122,6 +122,8 @@ VAGRANTFILE_API_VERSION = "2"
 #end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+
   config.vm.define "autoyast_vm" do |opensuse|
     opensuse.vm.box = "autoyast"
 


### PR DESCRIPTION
If an NFS server is available at the host system, it will try to install nfs utils in the guest. BTW, we don't need /vagrant folder.