### PR TITLE
Added test for btrfs /.snapshots created also on LVM

### DIFF
--- a/spec/btrfs_snapshots.sh
+++ b/spec/btrfs_snapshots.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e -x
+
+# See more at bsc#935858
+
+btrfs subvolume list / | grep '@/.snapshots' && SUBVOLUME_EXISTS=1
+
+grep '/\.snapshots .*subvol=@/\.snapshots' /etc/fstab && SUBVOLUME_IN_FSTAB=1
+
+if [ "${SUBVOLUME_EXISTS}" == "1" ] && [ "${SUBVOLUME_IN_FSTAB}" == "1"  ]; then
+  echo "AUTOYAST OK"
+else
+  echo "SCRIPT FAILURE: Subvolumes not configured"
+fi

--- a/spec/lvm.rb
+++ b/spec/lvm.rb
@@ -24,4 +24,9 @@ describe "LVM partition;" do
     run_test_script("installation_snapshot.sh")
   end
 
+  # bsc #935858
+  it "creates @/.snapshots on LVM" do
+    run_test_script("btrfs_snapshots.sh")
+  end
+
 end


### PR DESCRIPTION
- This is not tested in `autoyast-integration-test` but the script itself is tested on a system installed using lvm.xml (vagrant doesn't work for me)