### PR TITLE
Test that network settings are applied (bsc#949193).

### DIFF
--- a/lib/ay_tests/media_builder.rb
+++ b/lib/ay_tests/media_builder.rb
@@ -10,7 +10,7 @@ module AYTests
   class MediaBuilder
     include AYTests::Helpers
 
-    attr_reader :base_dir, :cache_dir, :local_packages_dir,
+    attr_reader :base_dir, :cache_dir,
       :local_packages_dir, :boot_dir, :iso_path, :obs_pkg_list_path, :yast_url,
       :iso_url, :version
 
@@ -25,7 +25,7 @@ module AYTests
     #   AYTests.base_dir.
     # @param [Pathname] yast_url YaST repository URL
     # @param [Pathname] iso_url  Base ISO URL
-    # @param [String]   version  Distribution version (+sle12+, +sle12_sp1+, etc.)
+    # @param [String]   version  Distribution version (+sles12+, +sles12-sp1+, etc.)
     # @param [Array<Hash>] extra_repos Extra repositories and packages to add to the
     #   ISO. The information for each repository consists in a Hash with +:server+
     #   and a +:packages+ keys.

--- a/spec/media_builder_spec.rb
+++ b/spec/media_builder_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AYTests::MediaBuilder do
   let(:base_dir) { Pathname.new("/home/autoyast") }
   let(:yast_url) { Pathname.new("http://build.suse.de/yast") }
   let(:iso_url) { Pathname.new("http://dl.suse.de/sles12.iso") }
-  let(:version) { "sle12" }
+  let(:version) { "sles12" }
   let(:output_path) { Pathname.new("/home/autoyast/output/testing.iso") }
 
   subject(:builder) do

--- a/test/ifcfg_networking.sh
+++ b/test/ifcfg_networking.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e -x
+
+# bsc#949193
+# Expect the network configuration to correspond to the XML profile.
+# The installation-time network setup has a plain STARTMODE=auto
+# so we check for the STARTMODE specified in XML <networking> element.
+grep "^STARTMODE.*nfsroot" /etc/sysconfig/network/ifcfg-eth0 && echo "AUTOYAST OK"

--- a/test/sles12.rb
+++ b/test/sles12.rb
@@ -66,4 +66,9 @@ describe "SLES 12 checks," do
     run_test_script("handle_zypper_pkg_gpg_check.sh")
   end
 
+  # bsc#949193
+  it "configures network interfaces" do
+    run_test_script("ifcfg_networking.sh")
+  end
+
 end


### PR DESCRIPTION
An integration test for https://github.com/yast/yast-network/pull/347

This will not test SLE12-GA updates, which is where this bug actually occurred. The test harness needs to be extended to test that.