### PR TITLE
Fixes from review

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ time. If for example you want to switch to VirtualBox, unload `kvm` kernel
 module and load `vboxdrv` and friends.
 
     # rmmod kvm
-    # rcboxdrv start
+    # rcvboxdrv start
 
 Caveats
 -------

--- a/lib/ay_tests/installer.rb
+++ b/lib/ay_tests/installer.rb
@@ -8,6 +8,7 @@ module AYTests
     GROUPS = ["libvirt", "qemu", "kvm", "vboxusers"]
     POLKIT_RULES_PATH = "/etc/polkit-1/rules.d/99-libvirt.rules"
     POLKIT_RULES_SAMPLE = File.join(File.dirname(__FILE__), "..", "..", "files", "99-libvirt.rules")
+    VAGRANT_LIBVIRT_VERSION = "0.0.32"
 
     # Constructor
     #
@@ -38,7 +39,7 @@ module AYTests
       install_packages_from_repos
       install_additional_packages
       reload_udev_rules
-      install_vagrant_plugin
+      install_vagrant_plugin(VAGRANT_LIBVIRT_VERSION)
 
       # Set up permissions
       add_user_to_groups
@@ -107,11 +108,13 @@ module AYTests
     #
     # Installation is skipped if plugin is installed for the current user.
     #
+    # @param [String] version Version needed.
+    #
     # Adapted from Pennyworth.
-    def install_vagrant_plugin
-      return if vagrant_libvirt_installed?
+    def install_vagrant_plugin(version)
+      return if vagrant_libvirt_installed?(version)
       log.info "Installing libvirt plugin for Vagrant"
-      Cheetah.run "vagrant", "plugin", "install", "vagrant-libvirt"
+      Cheetah.run "vagrant", "plugin", "install", "vagrant-libvirt", "--plugin-version", version
     end
 
     # Add user to virtualization groups
@@ -244,9 +247,13 @@ module AYTests
 
     # Check whether libvirt Vagrant plugin is installed or not
     #
+    # @param [String] version Version needed.
+    # @return [True,False] true if it's installed; false otherwise.
+    #
     # Adapted from Pennyworth.
-    def vagrant_libvirt_installed?
-      Cheetah.run(%w(vagrant plugin list), %w(grep vagrant-libvirt))
+    def vagrant_libvirt_installed?(version)
+      filter = "vagrant-libvirt .\*#{version}"
+      Cheetah.run(%w(vagrant plugin list), ["grep", "-E", filter])
       true
     rescue
       false


### PR DESCRIPTION
Some fixes after first @kobliha and @schubi2 tests:

* If a package is already installed, don't try to install it again (the package would be updated and we don't want to do that).
* Force installation of `vagrant-libvirt 0.0.32`.
* Fixed a typo in the documentation.