### PR TITLE
Run tests locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,19 @@ VirtualBox can run in headless mode if needed. To do that, just set the
 This setting is not relevant to libvirt/KVM which will run in *headless* mode
 anyway.
 
+### Running on local system
+
+Sometimes could be useful to run the tests in the local system. To do that,
+the `AYTESTS_LOCAL` environment variable should be set to `true`.
+
+    $ AYTESTS_LOCAL="true" bundle exec rspec <path/to/test.rb>
+
+For example:
+
+    $ bundle exec rspec test/sles12.rb
+
+Take into account that `sudo` will be used to execute testing scripts.
+
 ## Cleaning-up
 
 Two tasks for cleaning-up stuff are available. To remove cache

--- a/test/helpers.rb
+++ b/test/helpers.rb
@@ -1,0 +1,98 @@
+# Copyright (c) 2013-2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 3 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+
+require "open3"
+
+module Helpers
+  # Run a test script
+  #
+  # Run a script in the SUT and check if the last line matches
+  # the expected value. The script is supposed to live on test/
+  # directory.
+  #
+  # If ENV["AYTESTS_LOCAL"] == "true" then #local_run_test_script
+  # will be called. Otherwise, #remote_run_test_script will be used.
+  #
+  # @param [String] script   Script name
+  # @param [String] expected Expected value of stdout last line
+  def run_test_script(script, expected = "AUTOYAST OK")
+    shell =  File.join(File.dirname(__FILE__),"../test", script)
+    # Check if the script exists
+    expect(File.exists?(shell)).to eq(true), "test script does not exists: #{shell}"
+
+    if ENV["AYTESTS_LOCAL"] == "true"
+      local_run_test_script(shell, expected)
+    else
+      remote_run_test_script($vm, shell, expected)
+    end
+  end
+
+  # Run a test script in a SUT
+  #
+  # Run a script given the SUT is a virtual machine.
+  #
+  # @param [AYTests::VagrantRunner] runner   Virtual machine runner
+  # @param [String]                 script   Full path to the script
+  # @param [String]                 expected Expected value of stdout last line
+  def remote_run_test_script(vm, path, expected = "AUTOYAST OK")
+    result = vm.run(path, sudo: true)
+    expect(result[:stdout].split("\n").last).to eq(expected), proc { result[:stderr] }
+  end
+
+  # Run a test script in a SUT
+  #
+  # Run a script given the SUT is the local machine.
+  #
+  # @param [String]                 script   Full path to the script
+  # @param [String]                 expected Expected value of stdout last line
+  def local_run_test_script(path, expected = "AUTOYAST OK")
+    stdout, stderr, _status = Open3.capture3("sudo sh #{path}")
+    expect(stdout.split("\n").last).to eq(expected), proc { stderr }
+  end
+
+  # Copy YaST2 logs from virtual machine to a given directory
+  #
+  # It relies on AYTests::VagrantRunner#download_logs method.
+  # The logs will be stored in a tar.gz file. To avoid collisions,
+  # the compressed file's name will contain a timestamp.
+  #
+  # @param [AYTests::VagrantRunner] runner Virtual machine runner
+  # @param [String]                 dest   Directory where the logs will be stored
+  #
+  # @see AYTests::VagrantRunner#download_logs
+  def copy_logs(runner, dest = "log")
+    FileUtils.mkdir(dest) unless Dir.exists?(dest)
+    runner.download_logs(dest)
+  end
+
+  # Start a virtual machine
+  #
+  # @param [AYTests::VagrantRunner] runner Virtual machine runner
+  def start_vm(vm)
+    vm = AYTests::VagrantRunner.new(AYTests.base_dir.join("vagrant"), AYTests.provider)
+    vm.cleanup
+    vm.start
+  end
+
+  # Shutdown and clean up a virtual machine
+  #
+  # @param [AYTests::VagrantRunner] runner Virtual machine runner
+  def shutdown_vm(vm)
+    vm.stop
+    vm.cleanup
+  end
+end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -15,84 +15,10 @@
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
 
-require "ay_tests"
-require "open3"
-
-# Run a test script
-#
-# Run a script in the SUT and check if the last line matches
-# the expected value. The script is supposed to live on test/
-# directory.
-#
-# If ENV["AYTESTS_LOCAL"] == "true" then #local_run_test_script
-# will be called. Otherwise, #remote_run_test_script will be used.
-#
-# @param [String] script   Script name
-# @param [String] expected Expected value of stdout last line
-def run_test_script(script, expected = "AUTOYAST OK")
-  shell =  File.join(File.dirname(__FILE__),"../test", script)
-  # Check if the script exists
-  expect(File.exists?(shell)).to eq(true), "test script does not exists: #{shell}"
-
-  if ENV["AYTESTS_LOCAL"] == "true"
-    local_run_test_script(shell, expected)
-  else
-    remote_run_test_script(vm, shell, expected)
-  end
-end
-
-# Run a test script in a SUT
-#
-# Run a script given the SUT is a virtual machine.
-#
-# @param [AYTests::VagrantRunner] runner   Virtual machine runner
-# @param [String]                 script   Full path to the script
-# @param [String]                 expected Expected value of stdout last line
-def remote_run_test_script(vm, path, expected = "AUTOYAST OK")
-  result = vm.run(path, sudo: true)
-  expect(result[:stdout].split("\n").last).to eq(expected), proc { result[:stderr] }
-end
-
-# Run a test script in a SUT
-#
-# Run a script given the SUT is the local machine.
-#
-# @param [String]                 script   Full path to the script
-# @param [String]                 expected Expected value of stdout last line
-def local_run_test_script(path, expected = "AUTOYAST OK")
-  stdout, stderr, _status = Open3.capture3("sudo sh #{path}")
-  expect(stdout.split("\n").last).to eq(expected), proc { stderr }
-end
-
-# Copy YaST2 logs from virtual machine to a given directory
-#
-# It relies on AYTests::VagrantRunner#download_logs method.
-# The logs will be stored in a tar.gz file. To avoid collisions,
-# the compressed file's name will contain a timestamp.
-#
-# @param [AYTests::VagrantRunner] runner Virtual machine runner
-# @param [String]                 dest   Directory where the logs will be stored
-#
-# @see AYTests::VagrantRunner#download_logs
-def copy_logs(runner, dest = "log")
-  FileUtils.mkdir(dest) unless Dir.exists?(dest)
-  runner.download_logs(dest)
-end
-
-def start_vm(vm)
-  vm = AYTests::VagrantRunner.new(AYTests.base_dir.join("vagrant"), AYTests.provider)
-  vm.cleanup
-  vm.start
-end
-
-def shutdown_vm(vm)
-  vm.stop
-  vm.cleanup
-end
 
 RSpec.configure do |config|
-  config.before(:all) do
-    AYTests.base_dir = Pathname.new(File.dirname(__FILE__)).join("..")
+  require_relative "helpers"
+  config.include Helpers
 
   unless ENV["AYTESTS_LOCAL"] == "true"
     require "ay_tests"


### PR DESCRIPTION
This change will allow to run tests in the local system (without virtual machines). It's intended to be used by SLEPOS team on OpenQA.

Also RSpec helpers are moved to `test/helpers.rb`.