### PR TITLE
Fixed cleaning up old ISOs

### DIFF
--- a/lib/aytests/iso_repo.rb
+++ b/lib/aytests/iso_repo.rb
@@ -39,7 +39,7 @@ module AYTests
     def get(uri)
       iso_path = File.join(@dir, URI(uri).host, URI(uri).path)
       iso_dir = File.dirname(iso_path)
-      if uri.include?("*") || uri.include?("?")
+      if File.exist?(iso_dir) && (uri.include?("*") || uri.include?("?"))
         # We have wildcards in the uri. So we have to remove
         # old ISOs before because the name could have been changed
         # meanwhile.


### PR DESCRIPTION
Do not try removing the old ISO files when the target directory does not exist, fixes crash in the initial ISO build.

Fixes this issue:

```
I, [2016-04-20T10:23:45.038565 #19350]  INFO -- : Cleaning up /local/root/aytests-
workspace/cache
/usr/lib64/ruby/gems/2.1.0/gems/aytests-1.0.16/lib/aytests/iso_repo.rb:46:in `open
': No such file or directory @ dir_initialize - /local/root/aytests-workspace/iso/
download.suse.de/ibs/SUSE:/SLE-12-SP2:/GA:/Staging:/D/images/iso (Errno::ENOENT)
```