### PR TITLE
/sbin/udevadm compat symlink is gone (bsc#1160890)

### DIFF
--- a/lib/aytests/installer.rb
+++ b/lib/aytests/installer.rb
@@ -105,8 +105,8 @@ module AYTests
     # Adapted from Pennyworth.
     def reload_udev_rules
       log.info "Reloading udev rules"
-      Cheetah.run "sudo", "/sbin/udevadm", "control", "--reload-rules"
-      Cheetah.run "sudo", "/sbin/udevadm", "trigger"
+      Cheetah.run "sudo", "/usr/bin/udevadm", "control", "--reload-rules"
+      Cheetah.run "sudo", "/usr/bin/udevadm", "trigger"
     end
 
     # Install libvirt Vagrant plugin

--- a/package/rubygem-aytests.changes
+++ b/package/rubygem-aytests.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 23 12:26:55 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- /sbin/udevadm compat symlink is gone (bsc#1160890)
+- 1.0.66
+
+-------------------------------------------------------------------
 Thu Aug 22 16:44:19 CEST 2019 - schubi@suse.de
 
 - Using rb_default_ruby_abi tag in the spec file in order to

--- a/package/rubygem-aytests.spec
+++ b/package/rubygem-aytests.spec
@@ -17,7 +17,7 @@
 
 
 Name:           rubygem-aytests
-Version:        1.0.65
+Version:        1.0.66
 Release:        0
 %define mod_name aytests
 %define mod_full_name %{mod_name}-%{version}


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1160890
- https://trello.com/c/3Y9HSV8m

The `/sbin/udevadm` compat symlink has been removed from udevd package.

## Solution

Use `/usr/bin/udevadm`.